### PR TITLE
Updating README and resolving dependencies issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,23 @@
 ### How to Setup
 - Clone this repo `https://github.com/Ebryx/Nessus_Map.git`
 - Change directory `cd Nessus_Map`
+- Create a director named `XML`
 - Copy all `.nessus` files in `XML` directory
 - Start server with `python3 manage.py runserver`
+
+### Setting up with Python's Virtualenv
+```bash
+git clone https://github.com/Ebryx/Nessus_Map
+cd Nessus_Map
+mkdir env
+mkdir XML
+cd env
+python3 -m venv . 
+source bin/activate
+cd ..
+pip3 install -r requirements.txt
+python manage.py runserver
+```
 
 
 ### Vulnerability Parsing

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==1.11.29
 django-filebrowser==3.11.1
 django-grappelli==2.12.2
-Pillow==6.2.0
+Pillow==6.2.1
 pytz==2018.9


### PR DESCRIPTION
Updated README.md for building with `virtualenv` with `python3`. 

Resolved Pillow's dependency issue by upgrading `6.2.0` to `6.2.1`. Previously, following error was observed while installing requirements: 
![image](https://user-images.githubusercontent.com/18597330/86888058-00316d00-c113-11ea-9156-74d41d1be22f.png)
